### PR TITLE
Non referenced catch

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint:fix": "tsc --noEmit && eslint \"**/*.{js,ts}\" --quiet --fix",
     "prettier": "prettier --check \"**/*.{js,ts}\"",
     "prettier:fix": "prettier --write \"**/*.{js,ts}\"",
-    "test": "jest --silent",
+    "test": "jes --silent",
     "check": "npm run test && npm run lint && npm run prettier"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint:fix": "tsc --noEmit && eslint \"**/*.{js,ts}\" --quiet --fix",
     "prettier": "prettier --check \"**/*.{js,ts}\"",
     "prettier:fix": "prettier --write \"**/*.{js,ts}\"",
-    "test": "jes --silent",
+    "test": "jest --silent",
     "check": "npm run test && npm run lint && npm run prettier"
   },
   "repository": {

--- a/src/RequirementsQuery.ts
+++ b/src/RequirementsQuery.ts
@@ -92,6 +92,7 @@ async function queryBulkDataServer(url: string): Promise<void> {
   await axios
     .get(url, { headers })
     .then(resp => {
+      console.log(resp.headers['content-location']);
       probeServer(resp.headers['content-location']);
     })
     .catch(e => console.error(JSON.stringify(e.response.data, null, 4)));

--- a/test/ndjsonDisconnected/Encounter.ndjson
+++ b/test/ndjsonDisconnected/Encounter.ndjson
@@ -1,2 +1,3 @@
 {"resourceType":"Encounter","id":"1","subject":{"reference":"Patient/2"},"participant":[{"individual":{"reference":"Practitioner/3"}}]}
 {"resourceType":"Encounter","id":"4","reference":"Encounter/1"}
+{"resourceType":"Encounter","id":"7"}

--- a/test/ndjsonDisconnected/Observation.ndjson
+++ b/test/ndjsonDisconnected/Observation.ndjson
@@ -1,0 +1,1 @@
+{"resourceType":"Observation","id":"6","reference":"Encounter/4"}

--- a/test/ndjsonDisconnected/Patient.ndjson
+++ b/test/ndjsonDisconnected/Patient.ndjson
@@ -1,0 +1,1 @@
+{"resourceType":"Patient","id":"2"}

--- a/test/ndjsonDisconnected/Practitioner.ndjson
+++ b/test/ndjsonDisconnected/Practitioner.ndjson
@@ -1,0 +1,2 @@
+{"resourceType":"Practitioner","id":"3"}
+{"resourceType":"Practitioner", "id": "5"}

--- a/test/ndjsonDisconnected/disconnectedBundle.json
+++ b/test/ndjsonDisconnected/disconnectedBundle.json
@@ -1,0 +1,96 @@
+[
+  {
+    "resourceType": "Bundle",
+    "type": "transaction",
+    "entry": [
+      {
+        "resource": {
+          "resourceType": "Encounter",
+          "id": "1",
+          "subject": {
+            "reference": "Patient/2"
+          },
+          "participant": [
+            {
+              "individual": {
+                "reference": "Practitioner/3"
+              }
+            }
+          ]
+        },
+        "request": {
+          "method": "POST",
+          "url": "Encounter"
+        }
+      },
+      {
+        "resource": {
+          "resourceType": "Patient",
+          "id": "2"
+        },
+        "request": {
+          "method": "POST",
+          "url": "Patient"
+        }
+      },
+      {
+        "resource": {
+          "resourceType": "Practitioner",
+          "id": "3"
+        },
+        "request": {
+          "method": "POST",
+          "url": "Practitioner"
+        }
+      },
+      {
+        "request": {
+          "method": "POST",
+          "url": "Encounter"
+        },
+        "resource": {
+          "id": "4",
+          "reference": "Encounter/1",
+          "resourceType": "Encounter"
+        }
+      },
+      {
+        "request": {
+          "method": "POST",
+          "url": "Observation"
+        },
+        "resource": {
+          "resourceType": "Observation",
+          "id": "6",
+          "reference": "Encounter/4"
+        }
+      }
+    ]
+  },
+  {
+    "resourceType": "Bundle",
+    "type": "transaction",
+    "entry": [
+      {
+        "request": {
+          "method": "POST",
+          "url": "Practitioner"
+        },
+        "resource": {
+          "id": "5",
+          "resourceType": "Practitioner"
+        }
+      },
+      {
+        "request": {
+          "method": "POST",
+          "url": "Encounter"
+        },
+        "resource": {
+          "id": "7",
+          "resourceType": "Encounter"
+        }
+      }
+    ]
+  }
+]

--- a/test/ndjsonParser.test.ts
+++ b/test/ndjsonParser.test.ts
@@ -53,6 +53,11 @@ const EXPECTED_POPULATE_DB_RESOURCES = [
       '{"resourceType":"Encounter","id":"1","subject":{"reference":"Patient/2"},"participant":[{"individual":{"reference":"Practitioner/3"}}]}'
   },
   {
+    fhir_type: 'Encounter',
+    resource_id: '4',
+    resource_json: '{"resourceType":"Encounter","id":"4","reference":"Encounter/1"}'
+  },
+  {
     fhir_type: 'Patient',
     resource_id: '2',
     resource_json: '{"resourceType":"Patient","id":"2"}'
@@ -67,7 +72,8 @@ const EXPECTED_POPULATE_DB_RESOURCES = [
 
 const EXPECTED_POPULATE_DB_REFERENCES = [
   { origin_resource_id: '1', reference_id: '2' },
-  { origin_resource_id: '1', reference_id: '3' }
+  { origin_resource_id: '1', reference_id: '3' },
+  { origin_resource_id: '4', reference_id: '1' }
 ];
 
 describe('test ndjson parser functions', () => {

--- a/test/testFiles/testTransactionBundle.json
+++ b/test/testFiles/testTransactionBundle.json
@@ -1,46 +1,57 @@
 {
-    "resourceType": "Bundle",
-    "type": "transaction",
-    "entry": [
-        {
-            "resource": {
-                "resourceType": "Encounter",
-                "id": "1",
-                "subject": {
-                    "reference": "Patient/2"
-                },
-                "participant": [
-                    {
-                        "individual": {
-                            "reference": "Practitioner/3"
-                        }
-                    }
-                ]
-            },
-            "request": {
-                "method": "POST",
-                "url": "Encounter"
-            }
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "1",
+        "subject": {
+          "reference": "Patient/2"
         },
-        {
-            "resource": {
-                "resourceType": "Patient",
-                "id": "2"
-            },
-            "request": {
-                "method": "POST",
-                "url": "Patient"
+        "participant": [
+          {
+            "individual": {
+              "reference": "Practitioner/3"
             }
-        },
-        {
-            "resource": {
-                "resourceType": "Practitioner",
-                "id": "3"
-            },
-            "request": {
-                "method": "POST",
-                "url": "Practitioner"
-            }
-        }
-    ]
+          }
+        ]
+      },
+      "request": {
+        "method": "POST",
+        "url": "Encounter"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "2"
+      },
+      "request": {
+        "method": "POST",
+        "url": "Patient"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "3"
+      },
+      "request": {
+        "method": "POST",
+        "url": "Practitioner"
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "Encounter"
+      },
+      "resource": {
+        "id": "4",
+        "reference": "Encounter/1",
+        "resourceType": "Encounter"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
Previously, when converting ndjson to patient bundles, the assembleTransactionBundle function would only include resources which referenced a patient, or were referenced, by any degree of separation, by a resource which referenced the patient directly. Now, all ndjson resources should be accounted for in at least one bundle of the resulting transaction bundle array.

### New Behavior
- When recursively searching for the references of resources which directly reference a patient, getRecursiveReferences now checks each resource's incoming references as well as its outgoing references and adds them to the bundle if they have not already been added in a previous bundle.
- After assembling all patient bundles, assembleTransactionBundle now creates an additional bundle if there are resources in the ndjson that were not included in any of the bundles, and adds all such resources, as well as their references, to the new bundle.

### Code Changes
- Added a cleanUpLoop to assembleTransactionBundle which catches all resources that were not already added to other transaction bundles as well as their references
- Added a enteredResources set which keeps track of all resources that have been added to any transaction bundle
- Added testing for new functionality
- Added Matt's ndjsonConverter script to test/utils

### Testing Guidance
I added testing for this behavior, so run `npm run test` and ensure all the tests pass. Also, feel free to create your own ndjson resources and test them. You can use Matt's `ndjsonConverter` script in test/utils. Simply create an array of fhir resources inside test/util/resources.json, then run `ts-node test/ndjsonConverter`. Finally, add `assembleTransactionBundle('./test/fixtures/convertedResources', ':memory:').then(res =>
  console.log(JSON.stringify(res, null, 4))
);` 
to the end of `src/utils/bundleAssemblyHelpers.ts`, then run `ts-node src/utils/bundleAssemblyHelpers.ts>output.json` and inspect the output in output.json for errors. You can even copy and paste the bundles one at a time into the body of a POST request to the base url of deqm-test-server to ensure the formatting is correct.