### PR TITLE
No mb export

### DIFF
--- a/src/RequirementsQuery.ts
+++ b/src/RequirementsQuery.ts
@@ -180,5 +180,12 @@ async function retrieveBulkDataFromRequirements(
   return await queryBulkDataServer(url);
 }
 
+export async function retrieveAllBulkData(
+  exportURL: string
+): Promise<{ output?: BulkDataResponse[] | null; error?: string }> {
+  const url = `${exportURL}/$export?`;
+  return await queryBulkDataServer(url);
+}
+
 //retrieveBulkDataFromMeasureBundlePath(exampleMeasureBundle, API_URL); //UNCOMMENT TO RUN API REQUEST WITH DESIRED MEASUREBUNDLE FILE (Will almost certainly cause an error)
 //retrieveBulkDataFromRequirements(EXAMPLE_REQUIREMENTS, API_URL); //UNCOMMENT TO RUN API REQUEST WITH EXAMPLE DATA REQUIREMENTS

--- a/src/RequirementsQuery.ts
+++ b/src/RequirementsQuery.ts
@@ -100,7 +100,6 @@ export const getDataRequirementsQueries = (dataRequirements: fhir4.DataRequireme
  */
 async function retrieveBulkDataFromMeasureBundlePath(measureBundle: string, exportURL: string) {
   const dr = Calculator.calculateDataRequirements(parseBundle(measureBundle));
-  console.log(JSON.stringify(dr.results.dataRequirement, null, 4));
   if (!dr.results.dataRequirement) {
     dr.results.dataRequirement = [];
   }
@@ -147,7 +146,7 @@ async function retrieveBulkDataFromRequirements(
 export async function retrieveAllBulkData(
   exportURL: string
 ): Promise<{ output?: BulkDataResponse[] | null; error?: string }> {
-  const url = `${exportURL}/$export`;
+  const url = `${exportURL}/$export?_type=Encounter,Condition,Location,Patient`;
   return await queryBulkDataServer(url);
 }
 

--- a/src/RequirementsQuery.ts
+++ b/src/RequirementsQuery.ts
@@ -146,7 +146,7 @@ async function retrieveBulkDataFromRequirements(
 export async function retrieveAllBulkData(
   exportURL: string
 ): Promise<{ output?: BulkDataResponse[] | null; error?: string }> {
-  const url = `${exportURL}/$export?_type=Encounter,Condition,Location,Patient`;
+  const url = `${exportURL}/$export`;
   return await queryBulkDataServer(url);
 }
 

--- a/src/bulkImportWrappers.ts
+++ b/src/bulkImportWrappers.ts
@@ -14,6 +14,7 @@ export async function executeBulkImport(
   } else {
     ({ output: bulkDataResponses } = await retrieveAllBulkData(exportUrl));
   }
+  console.log(bulkDataResponses);
   if (bulkDataResponses) {
     const db = await populateDB(bulkDataResponses, location);
     const tbArr = await assembleTransactionBundles(db);
@@ -21,3 +22,7 @@ export async function executeBulkImport(
     return tbArr;
   }
 }
+
+executeBulkImport('http://localhost:3000', ':memory:')
+  .then(res => console.log(res))
+  .catch(e => console.log(e.message));

--- a/src/bulkImportWrappers.ts
+++ b/src/bulkImportWrappers.ts
@@ -14,7 +14,6 @@ export async function executeBulkImport(
   } else {
     ({ output: bulkDataResponses } = await retrieveAllBulkData(exportUrl));
   }
-  console.log(bulkDataResponses);
   if (bulkDataResponses) {
     const db = await populateDB(bulkDataResponses, location);
     const tbArr = await assembleTransactionBundles(db);
@@ -22,7 +21,3 @@ export async function executeBulkImport(
     return tbArr;
   }
 }
-
-executeBulkImport('http://localhost:3000', ':memory:')
-  .then(res => console.log(res))
-  .catch(e => console.log(e.message));

--- a/src/bulkImportWrappers.ts
+++ b/src/bulkImportWrappers.ts
@@ -1,14 +1,19 @@
-import { retrieveBulkDataFromMeasureBundle } from './RequirementsQuery';
+import { retrieveAllBulkData, retrieveBulkDataFromMeasureBundle } from './RequirementsQuery';
 import { populateDB } from './utils/ndjsonParser';
 import { assembleTransactionBundles } from './utils/bundleAssemblyHelpers';
 import { TransactionBundle } from './types/TransactionBundle';
 
 export async function executeBulkImport(
-  mb: fhir4.Bundle,
   exportUrl: string,
-  location: string
+  location: string,
+  mb?: fhir4.Bundle
 ): Promise<TransactionBundle[] | void> {
-  const { output: bulkDataResponses } = await retrieveBulkDataFromMeasureBundle(mb, exportUrl);
+  let bulkDataResponses = null;
+  if (mb) {
+    ({ output: bulkDataResponses } = await retrieveBulkDataFromMeasureBundle(mb, exportUrl));
+  } else {
+    ({ output: bulkDataResponses } = await retrieveAllBulkData(exportUrl));
+  }
   if (bulkDataResponses) {
     const db = await populateDB(bulkDataResponses, location);
     const tbArr = await assembleTransactionBundles(db);

--- a/src/exportServerQueries.ts
+++ b/src/exportServerQueries.ts
@@ -14,7 +14,6 @@ const headers = {
 export async function queryBulkDataServer(url: string): Promise<{ output: BulkDataResponse[] | null; error?: string }> {
   try {
     const resp = await axios.get(url, { headers });
-    console.log(resp.headers['content-location']);
     return await probeServer(resp.headers['content-location']);
   } catch (err) {
     return { output: null, error: (err as AxiosError).message };
@@ -32,16 +31,13 @@ function sleep(ms: number) {
  */
 
 export async function probeServer(url: string): Promise<{ output: BulkDataResponse[] }> {
-  console.log('reached');
-  let results = await axios.get(`http://localhost:3000${url}`, { headers });
-  console.log(results);
+  let results = await axios.get(url, { headers });
   while (results.status === 202) {
     await sleep(1000);
-    results = await axios.get(`http://localhost:3000${url}`, { headers });
-    console.log(results);
+    results = await axios.get(url, { headers });
   }
   if (results.status === 500) {
     throw new Error('Received 500 status: Internal Server Error');
   }
-  return { output: results.data.outcome };
+  return { output: results.data.output };
 }

--- a/src/exportServerQueries.ts
+++ b/src/exportServerQueries.ts
@@ -1,0 +1,47 @@
+import axios, { AxiosError } from 'axios';
+import { BulkDataResponse } from './types/RequirementsQueryTypes';
+
+const headers = {
+  Accept: 'application/fhir+json',
+  Prefer: 'respond-async'
+};
+
+/**
+ * sends initial request to bulk data export server and calls recurring poll function
+ * to check on progress
+ * @param url: A bulk data export FHIR server url with params
+ */
+export async function queryBulkDataServer(url: string): Promise<{ output: BulkDataResponse[] | null; error?: string }> {
+  try {
+    const resp = await axios.get(url, { headers });
+    console.log(resp.headers['content-location']);
+    return await probeServer(resp.headers['content-location']);
+  } catch (err) {
+    return { output: null, error: (err as AxiosError).message };
+  }
+}
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Repeatedly checks the passed url (every second) until the request either fails or succeeds
+ * @param url: A content-location url retrieved by queryBulkDataServer which will
+ * eventually contain the output data when processing completes
+ */
+
+export async function probeServer(url: string): Promise<{ output: BulkDataResponse[] }> {
+  console.log('reached');
+  let results = await axios.get(`http://localhost:3000${url}`, { headers });
+  console.log(results);
+  while (results.status === 202) {
+    await sleep(1000);
+    results = await axios.get(`http://localhost:3000${url}`, { headers });
+    console.log(results);
+  }
+  if (results.status === 500) {
+    throw new Error('Received 500 status: Internal Server Error');
+  }
+  return { output: results.data.outcome };
+}

--- a/src/utils/ndjsonParser.ts
+++ b/src/utils/ndjsonParser.ts
@@ -72,8 +72,9 @@ export async function createDatabase(location: string): Promise<sqlite.Database>
   await DB.run(
     `CREATE TABLE "fhir_resources"(
             "fhir_type"     Text,
-            "resource_id"   Text PRIMARY KEY,
-            "resource_json" Text
+            "resource_id"   Text,
+            "resource_json" Text,
+            PRIMARY KEY("fhir_type", "resource_id")
         );`
   );
   await DB.run('DROP TABLE IF EXISTS "local_references"');

--- a/test/RequirementsQuery.test.ts
+++ b/test/RequirementsQuery.test.ts
@@ -1,4 +1,5 @@
-import { getDataRequirementsQueries, queryBulkDataServer } from '../src/RequirementsQuery';
+import * as exportQueries from '../src/exportServerQueries';
+import { retrieveAllBulkData, getDataRequirementsQueries } from '../src/RequirementsQuery';
 
 const DATA_REQUIREMENTS_PATIENT = [
   {
@@ -92,9 +93,6 @@ const EXPECTED_DATA_REQUIREMENTS_ENCOUNTER_IS_CODE = {
   _typeFilter: 'Encounter%3Fcode=TEST_CODE'
 };
 
-const invalidURL = 'not-a-real-url';
-const invalidURLError = { output: null, error: 'connect ECONNREFUSED 127.0.0.1:80' };
-
 /*
 NOTE: codeFilter code has been commented out in order to test
 bulkImport in deqm-test-server. Otherwise, errors arise since
@@ -127,9 +125,13 @@ describe.skip('getDataRequirements Tests', () => {
     );
   });
 });
-describe('queryBulkServer Tests', () => {
-  test('Throw error if invalid export URL given to queryBulkDataServer', async () => {
-    const results = await queryBulkDataServer(invalidURL);
-    expect(results).toEqual(invalidURLError);
+
+describe('retrieveAllBulkData Tests', () => {
+  test('Should call queryBulkDataServer with no type filters', async () => {
+    const qbdSpy = jest.spyOn(exportQueries, 'queryBulkDataServer').mockImplementationOnce(async () => {
+      return { output: null };
+    });
+    await retrieveAllBulkData('https://example.com');
+    expect(qbdSpy).toHaveBeenCalledWith('https://example.com/$export');
   });
 });

--- a/test/exportServerQueries.test.ts
+++ b/test/exportServerQueries.test.ts
@@ -1,0 +1,11 @@
+import { queryBulkDataServer } from '../src/exportServerQueries';
+
+const invalidURL = 'not-a-real-url';
+const invalidURLError = { output: null, error: 'connect ECONNREFUSED 127.0.0.1:80' };
+
+describe('queryBulkServer Tests', () => {
+  test('Throw error if invalid export URL given to queryBulkDataServer', async () => {
+    const results = await queryBulkDataServer(invalidURL);
+    expect(results).toEqual(invalidURLError);
+  });
+});


### PR DESCRIPTION
# Summary
Previously, we could only use bulk export with a passed-in measure bundle. Now, executing a bulk export without a measure bundle will simply export all the resources on the server. 

## New Behavior
The measureBundle argument to executeBulkImport is now optional. Omitting it will cause the export server to return all resources

## Code Changes
- The measureBundle argument in the executeBulkExport function is now optional
- Added utility functions to handle export of all resources when measureBundle is not provided
- Added new file `export server queries` for organization and mocking purposes

# Testing Guidance
Testing is a little weird here since the smart-on-fhir server contains references to resources which don't exist and our bulk export server is currently struggling with some library references. The best way to test is to alter the url which eventually makes the export request in `RequirementsQueries.ts`. First, add 
`executeBulkImport('http://localhost:3000', ':memory:')
  .then(res => console.log(JSON.stringify(res, null, 4)))
  .catch(e => console.log(e.message));`

to the bottom of src/bulkImportWrappers.ts. Then, change line 150 in `src/RequirementsQuery` from 
``const url = `${exportURL}/$export`; ``to 
``const url = `${exportURL}/$export?_type=Encounter,Condition,Location,Patient`;``
now run `ts-node src/bulkImportWrappers > output.json`. The output.json file should contain a collection of transaction bundles, with every Encounter, Condition, Location, and Patient resource represented from the Connectathon bundles.