### PR TITLE
Temporary db deletion

### DIFF
--- a/src/bulkImportWrappers.ts
+++ b/src/bulkImportWrappers.ts
@@ -2,6 +2,7 @@ import { retrieveAllBulkData, retrieveBulkDataFromMeasureBundle } from './Requir
 import { populateDB } from './utils/ndjsonParser';
 import { assembleTransactionBundles } from './utils/bundleAssemblyHelpers';
 import { TransactionBundle } from './types/TransactionBundle';
+import { rmSync } from 'fs';
 
 export async function executeBulkImport(
   exportUrl: string,
@@ -18,6 +19,7 @@ export async function executeBulkImport(
     const db = await populateDB(bulkDataResponses, location);
     const tbArr = await assembleTransactionBundles(db);
     await db.close();
+    rmSync(location);
     return tbArr;
   }
 }


### PR DESCRIPTION
# Summary
Added a step to remove the temporary db created during populateDB function

## New Behavior
When running bulkImport requests, the server's directory will no longer get cluttered with temporary database files that persist after the run

## Code Changes
rly?

# Testing Guidance
Use the testing guidance in this [PR](https://github.com/projecttacoma/deqm-test-server/pull/54#partial-pull-merging) to see that `$import` can be run without adding temp db files