### PR TITLE
Remove DB Files in Error Cases

### DIFF
--- a/src/bulkImportWrappers.ts
+++ b/src/bulkImportWrappers.ts
@@ -16,10 +16,16 @@ export async function executeBulkImport(
     ({ output: bulkDataResponses } = await retrieveAllBulkData(exportUrl));
   }
   if (bulkDataResponses) {
-    const db = await populateDB(bulkDataResponses, location);
-    const tbArr = await assembleTransactionBundles(db);
-    await db.close();
-    rmSync(location);
-    return tbArr;
+    try {
+      const db = await populateDB(bulkDataResponses, location);
+      const tbArr = await assembleTransactionBundles(db);
+      await db.close();
+      rmSync(location);
+      return tbArr;
+    } catch (e) {
+      // ensure created database file is removed before error is thrown
+      rmSync(location);
+      throw e;
+    }
   }
 }


### PR DESCRIPTION
# Summary
This PR removes the db files that are created in all cases of output from the bulk import operation rather than only the successful outputs.

## New behavior
Previously, the sqlite database files were only removed in the case of a successful import. However, in the case of an unsuccessful import, we still want to remove the database files so that they do not clutter the repo. Now, they will also be removed prior to an error being thrown, if there is an error.

## Code changes
A try/catch statement was added in `executeBulkImport()` to handle the errors that bubble up. Before throwing the error, the database `location` will be deleted.

# Testing guidance
A good way to test this is to throw an import reference error. 

- In the bulk export server, run `npm run db:reset`, followed by `npm run connectathon-upload`. Then, do the same in the deqm test server.
- `npm link` bulk data utilities to deqm test server so that we can test out these changes.
- Start running the bulk export server
- Start running the deqm test server
- send a `POST` request to `http://localhost:3000/4_0_1/$import` (non-measure-specific import)
- send a `GET` request to `http://localhost:3000/4_0_1/bulkstatus/<content-location>`, where the content location is from the `Content-Location` header from the `POST` request.
- You should get a 500 Internal Service Error in Insomnia for an unresolved reference.
- **Check that no db files were created within deqm test server.**

Note that the db files are never created in the first place if there is an error from the export server, so testing out export server errors will not be testing this new functionality.