### PR TITLE
Code from Connectathon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2518,15 +2518,6 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
-    "@types/walk": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@types/walk/-/walk-2.3.1.tgz",
-      "integrity": "sha512-gEH9G1wA3xKfAgQmJJA/Kdk5Ne9xI1Gn/q2Dwfl06m7IsgEBUUBVzSVfbi9zf6KYL4xfA6tFtzOQk9p0vBzLDg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/yargs": {
       "version": "16.0.4",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
@@ -4321,11 +4312,6 @@
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "optional": true
-    },
-    "foreachasync": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
-      "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -7934,14 +7920,6 @@
       "dev": true,
       "requires": {
         "xml-name-validator": "^3.0.0"
-      }
-    },
-    "walk": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.14.tgz",
-      "integrity": "sha512-5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==",
-      "requires": {
-        "foreachasync": "^3.0.0"
       }
     },
     "walker": {

--- a/package.json
+++ b/package.json
@@ -11,15 +11,13 @@
     "fqm-execution": "^0.8.0",
     "path": "^0.12.7",
     "sqlite": "^4.0.23",
-    "sqlite3": "^5.0.2",
-    "walk": "^2.3.14"
+    "sqlite3": "^5.0.2"
   },
   "devDependencies": {
     "@types/fhir": "0.0.34",
     "@types/jest": "^27.0.0",
     "@types/node": "^14.17.7",
     "@types/sqlite3": "^3.1.7",
-    "@types/walk": "^2.3.1",
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",
     "axios-mock-adapter": "^1.20.0",

--- a/src/bulkImportWrappers.ts
+++ b/src/bulkImportWrappers.ts
@@ -1,14 +1,20 @@
 import { retrieveAllBulkData, retrieveBulkDataFromMeasureBundle } from './utils/requirementsQueryBuilder';
 import { BulkDataResponse } from './types/requirementsQueryTypes';
 
-export async function executeBulkImport(exportUrl: string, mb?: fhir4.Bundle): Promise<BulkDataResponse[] | undefined> {
+export async function executeBulkImport(
+  exportUrl: string,
+  mb?: fhir4.Bundle,
+  useTypeFilters?: boolean
+): Promise<BulkDataResponse[] | null> {
   let bulkDataResponses = null;
   if (mb) {
-    ({ output: bulkDataResponses } = await retrieveBulkDataFromMeasureBundle(mb, exportUrl));
+    ({ output: bulkDataResponses } = await retrieveBulkDataFromMeasureBundle(mb, exportUrl, useTypeFilters));
   } else {
     ({ output: bulkDataResponses } = await retrieveAllBulkData(exportUrl));
   }
   if (bulkDataResponses) {
     return bulkDataResponses;
   }
+
+  return null;
 }

--- a/src/bulkImportWrappers.ts
+++ b/src/bulkImportWrappers.ts
@@ -1,14 +1,7 @@
 import { retrieveAllBulkData, retrieveBulkDataFromMeasureBundle } from './utils/requirementsQueryBuilder';
-import { populateDB } from './utils/ndjsonParser';
-import { assembleTransactionBundles } from './utils/bundleAssemblyHelpers';
-import { TransactionBundle } from './types/transactionBundle';
-import { rmSync } from 'fs';
+import { BulkDataResponse } from './types/requirementsQueryTypes';
 
-export async function executeBulkImport(
-  exportUrl: string,
-  location: string,
-  mb?: fhir4.Bundle
-): Promise<TransactionBundle[] | void> {
+export async function executeBulkImport(exportUrl: string, mb?: fhir4.Bundle): Promise<BulkDataResponse[] | undefined> {
   let bulkDataResponses = null;
   if (mb) {
     ({ output: bulkDataResponses } = await retrieveBulkDataFromMeasureBundle(mb, exportUrl));
@@ -16,16 +9,6 @@ export async function executeBulkImport(
     ({ output: bulkDataResponses } = await retrieveAllBulkData(exportUrl));
   }
   if (bulkDataResponses) {
-    try {
-      const db = await populateDB(bulkDataResponses, location);
-      const tbArr = await assembleTransactionBundles(db);
-      await db.close();
-      rmSync(location);
-      return tbArr;
-    } catch (e) {
-      // ensure created database file is removed before error is thrown
-      rmSync(location);
-      throw e;
-    }
+    return bulkDataResponses;
   }
 }

--- a/src/types/requirementsQueryTypes.ts
+++ b/src/types/requirementsQueryTypes.ts
@@ -8,7 +8,7 @@ export interface DRQuery {
 
 export interface APIParams {
   _type: string;
-  _typeFilter: string;
+  _typeFilter?: string;
 }
 
 export interface BulkDataResponse {

--- a/src/utils/requirementsQueryBuilder.ts
+++ b/src/utils/requirementsQueryBuilder.ts
@@ -60,7 +60,7 @@ export async function retrieveBulkDataFromMeasureBundle(
   if (!dr.results.dataRequirement) {
     dr.results.dataRequirement = [];
   }
-  return await retrieveBulkDataFromRequirements(dr.results.dataRequirement, exportUrl);
+  return await retrieveBulkDataFromRequirements(dr.results.dataRequirement, exportUrl, useTypeFilters);
 }
 
 /**

--- a/src/utils/requirementsQueryBuilder.ts
+++ b/src/utils/requirementsQueryBuilder.ts
@@ -66,7 +66,12 @@ async function retrieveBulkDataFromRequirements(
   exportUrl: string
 ): Promise<{ output?: BulkDataResponse[] | null; error?: string }> {
   const params = getDataRequirementsQueries(requirements);
-  const url = `${exportUrl}?_type=${params._type}&_typeFilter=${params._typeFilter}`;
+  let url = `${exportUrl}?_type=${params._type}`;
+
+  if (params._typeFilter) {
+    url += `&_typeFilter=${params._typeFilter}`;
+  }
+
   return await queryBulkDataServer(url);
 }
 

--- a/src/utils/requirementsQueryBuilder.ts
+++ b/src/utils/requirementsQueryBuilder.ts
@@ -8,7 +8,10 @@ import { queryBulkDataServer } from './exportServerQueryBuilder';
  * @param dataRequirements: An array of data requirements as returned from fqm-execution
  * @returns APIParams: An object containing the _type and _typeFilter strings to be appended to the URL as parameters
  */
-export const getDataRequirementsQueries = (dataRequirements: fhir4.DataRequirement[]): APIParams => {
+export const getDataRequirementsQueries = (
+  dataRequirements: fhir4.DataRequirement[],
+  useTypeFilters?: boolean
+): APIParams => {
   const queries: DRQuery[] = [];
 
   // converts dataRequirements output into a format easily parsed into URL params
@@ -26,16 +29,20 @@ export const getDataRequirementsQueries = (dataRequirements: fhir4.DataRequireme
     return acc;
   }, []);
   const formattedTypes = uniqTypes.join(',');
-  const formattedTypeFilter = queries.reduce((acc: string[], e) => {
-    //if the params object is empty, we dont want to add any params
-    if (Object.keys(e.params).length > 0) {
-      acc.push(`${e.endpoint}%3F${new URLSearchParams(e.params).toString()}`);
-    }
-    return acc;
-  }, []);
-  const typeFilterString = formattedTypeFilter.join(',');
 
-  return { _type: formattedTypes, _typeFilter: typeFilterString };
+  let typeFilterString = '';
+  if (useTypeFilters) {
+    const formattedTypeFilter = queries.reduce((acc: string[], e) => {
+      //if the params object is empty, we dont want to add any params
+      if (Object.keys(e.params).length > 0) {
+        acc.push(`${e.endpoint}%3F${new URLSearchParams(e.params).toString()}`);
+      }
+      return acc;
+    }, []);
+    typeFilterString = formattedTypeFilter.join(',');
+  }
+
+  return { _type: formattedTypes, ...(useTypeFilters ? { _typeFilter: typeFilterString } : {}) };
 };
 
 /**
@@ -46,7 +53,8 @@ export const getDataRequirementsQueries = (dataRequirements: fhir4.DataRequireme
 
 export async function retrieveBulkDataFromMeasureBundle(
   measureBundle: fhir4.Bundle,
-  exportUrl: string
+  exportUrl: string,
+  useTypeFilters?: boolean
 ): Promise<{ output?: BulkDataResponse[] | null; error?: string }> {
   const dr = Calculator.calculateDataRequirements(measureBundle);
   if (!dr.results.dataRequirement) {
@@ -63,9 +71,10 @@ export async function retrieveBulkDataFromMeasureBundle(
 
 async function retrieveBulkDataFromRequirements(
   requirements: fhir4.DataRequirement[],
-  exportUrl: string
+  exportUrl: string,
+  useTypeFilters?: boolean
 ): Promise<{ output?: BulkDataResponse[] | null; error?: string }> {
-  const params = getDataRequirementsQueries(requirements);
+  const params = getDataRequirementsQueries(requirements, useTypeFilters);
   let url = `${exportUrl}?_type=${params._type}`;
 
   if (params._typeFilter) {


### PR DESCRIPTION
# Summary

Simplifies interface to not force sqlite referential integrity. Kept the code in case we want to repurpose later, but for now just acts as bulk export client and passes back the ndjson results to the caller.

## New behavior

No sqlite. Blazing fast.

## Code changes

Removed unused dependencies. Remove sqlite reference checking. Added boolean option for whether or not to use typeFilter parsing in request since we want to configure this based on which export server we're using

# Testing guidance

Basically just https://github.com/projecttacoma/deqm-test-server/pull/73/ and unit tests
