### PR TITLE
Re-add typefilter parameter parsing when flag is enabled

### DIFF
--- a/src/utils/requirementsQueryBuilder.ts
+++ b/src/utils/requirementsQueryBuilder.ts
@@ -18,6 +18,13 @@ export const getDataRequirementsQueries = (
   dataRequirements.forEach(dr => {
     if (dr.type) {
       const q: DRQuery = { endpoint: dr.type, params: {} };
+      if (dr?.codeFilter?.[0]?.code?.[0]) {
+        const key = dr?.codeFilter?.[0].path;
+        key && (q.params[key] = dr.codeFilter[0].code[0].code);
+      } else if (dr?.codeFilter?.[0]?.valueSet) {
+        const key = `${dr?.codeFilter?.[0].path}:in`;
+        key && (q.params[key] = dr.codeFilter[0].valueSet);
+      }
       queries.push(q);
     }
   });

--- a/test/requirementsQueryBuilder.test.ts
+++ b/test/requirementsQueryBuilder.test.ts
@@ -93,34 +93,34 @@ const EXPECTED_DATA_REQUIREMENTS_ENCOUNTER_IS_CODE = {
   _typeFilter: 'Encounter%3Fcode=TEST_CODE'
 };
 
-/*
-NOTE: codeFilter code has been commented out in order to test
-bulkImport in deqm-test-server. Otherwise, errors arise since
-the $export reference server does not support _typeFilter.
-
-If these tests are run with the codeFilter code commented out,
-they will fail. To run these tests, first uncomment the
-codeFilter code in the getDataRequirementsQueries function.
-*/
-describe.skip('getDataRequirements Tests', () => {
-  test('Patient type request', () => {
-    expect(getDataRequirementsQueries(DATA_REQUIREMENTS_PATIENT)).toEqual(EXPECTED_DATA_REQUIREMENTS_PATIENT);
+describe('getDataRequirements Tests', () => {
+  test('useTypeFilters false should not generate any', () => {
+    const query = getDataRequirementsQueries(DATA_REQUIREMENTS_PATIENT, false);
+    expect(query._typeFilter).toBeUndefined();
   });
+
+  test('Patient type request', () => {
+    expect(getDataRequirementsQueries(DATA_REQUIREMENTS_PATIENT, true)).toEqual(EXPECTED_DATA_REQUIREMENTS_PATIENT);
+  });
+
   test('Procedure in valueset request', () => {
-    expect(getDataRequirementsQueries(DATA_REQUIREMENTS_PROCEDURE_W_VALUESET)).toEqual(
+    expect(getDataRequirementsQueries(DATA_REQUIREMENTS_PROCEDURE_W_VALUESET, true)).toEqual(
       EXPECTED_DATA_REQUIREMENTS_PROCEDURE_W_VALUESET
     );
   });
+
   test('Encounter with code in valueset request', () => {
-    expect(getDataRequirementsQueries(DATA_REQUIREMENTS_ENCOUNTER_W_CODE)).toEqual(
+    expect(getDataRequirementsQueries(DATA_REQUIREMENTS_ENCOUNTER_W_CODE, true)).toEqual(
       EXPECTED_DATA_REQUIREMENTS_ENCOUNTER_W_CODE
     );
   });
+
   test('Multiple requirements', () => {
-    expect(getDataRequirementsQueries(DATA_REQUIREMENTS_MULTIPLE)).toEqual(EXPECTED_DATA_REQUIREMENTS_MULTIPLE);
+    expect(getDataRequirementsQueries(DATA_REQUIREMENTS_MULTIPLE, true)).toEqual(EXPECTED_DATA_REQUIREMENTS_MULTIPLE);
   });
+
   test('Encounter with code equals', () => {
-    expect(getDataRequirementsQueries(DATA_REQUIREMENTS_ENCOUNTER_IS_CODE)).toEqual(
+    expect(getDataRequirementsQueries(DATA_REQUIREMENTS_ENCOUNTER_IS_CODE, true)).toEqual(
       EXPECTED_DATA_REQUIREMENTS_ENCOUNTER_IS_CODE
     );
   });


### PR DESCRIPTION
# Summary

We initially had a commented out block of code for mapping the DataRequirements to `_typeFilter` parameters that got deleted when we cleaned up the repo. it was commented out bc the servers we were testing with did not support the `_typeFilter` parameter, so we didn't want to include it on our requests.

At the connectathon, we added a `useTypeFilters` flag that will only compute the param if specified by the client. This PR adds back the code for properly assembling the params for a typeFilter, and does it only if the flag is true

## New behavior

`_typeFilter` actually works, unskipped tests will pass (used to fail)

## Code changes

* Add old param parsing code 
* Unskip tests and ensure they set the useTypeFilter flag to true
* Added test for proper logic of flag

# Testing guidance

Run tests, link to deqm-test-server and run bulk operations. Should be no changed behavior
