### PR TITLE
May 2022 connectathon changes

### DIFF
--- a/src/utils/requirementsQueryBuilder.ts
+++ b/src/utils/requirementsQueryBuilder.ts
@@ -76,7 +76,7 @@ export async function retrieveBulkDataFromMeasureBundle(
  * @param exportUrl: export server URL string
  */
 
-async function retrieveBulkDataFromRequirements(
+export async function retrieveBulkDataFromRequirements(
   requirements: fhir4.DataRequirement[],
   exportUrl: string,
   useTypeFilters?: boolean
@@ -90,7 +90,7 @@ async function retrieveBulkDataFromRequirements(
 
   if (!exportUrl.includes('_typeFilter=')) {
     if (params._typeFilter) {
-      url += `${exportUrl.includes('_type=') ? '&' : '?'}_typeFilter=${params._typeFilter}`;
+      url += `${url.includes('_type=') ? '&' : '?'}_typeFilter=${params._typeFilter}`;
     }
   }
 

--- a/src/utils/requirementsQueryBuilder.ts
+++ b/src/utils/requirementsQueryBuilder.ts
@@ -82,6 +82,13 @@ async function retrieveBulkDataFromRequirements(
   useTypeFilters?: boolean
 ): Promise<{ output?: BulkDataResponse[] | null; error?: string }> {
   const params = getDataRequirementsQueries(requirements, useTypeFilters);
+
+  //TODO: figure out how to override this if exportUrl contains these already
+  // contains _type and _typeFilter, just _type, just _typeFilter
+  let url = exportUrl;
+  if (!exportUrl.includes('_type=') {
+    
+  }
   let url = `${exportUrl}?_type=${params._type}`;
 
   if (params._typeFilter) {

--- a/src/utils/requirementsQueryBuilder.ts
+++ b/src/utils/requirementsQueryBuilder.ts
@@ -83,16 +83,15 @@ async function retrieveBulkDataFromRequirements(
 ): Promise<{ output?: BulkDataResponse[] | null; error?: string }> {
   const params = getDataRequirementsQueries(requirements, useTypeFilters);
 
-  //TODO: figure out how to override this if exportUrl contains these already
-  // contains _type and _typeFilter, just _type, just _typeFilter
   let url = exportUrl;
-  if (!exportUrl.includes('_type=') {
-    
+  if (!exportUrl.includes('_type=')) {
+    url += `${exportUrl.includes('_typeFilter=') ? '&' : '?'}_type=${params._type}`;
   }
-  let url = `${exportUrl}?_type=${params._type}`;
 
-  if (params._typeFilter) {
-    url += `&_typeFilter=${params._typeFilter}`;
+  if (!exportUrl.includes('_typeFilter=')) {
+    if (params._typeFilter) {
+      url += `${exportUrl.includes('_type=') ? '&' : '?'}_typeFilter=${params._typeFilter}`;
+    }
   }
 
   return await queryBulkDataServer(url);

--- a/test/requirementsQueryBuilder.test.ts
+++ b/test/requirementsQueryBuilder.test.ts
@@ -1,5 +1,9 @@
 import * as exportQueries from '../src/utils/exportServerQueryBuilder';
-import { retrieveAllBulkData, getDataRequirementsQueries } from '../src/utils/requirementsQueryBuilder';
+import {
+  retrieveAllBulkData,
+  getDataRequirementsQueries,
+  retrieveBulkDataFromRequirements
+} from '../src/utils/requirementsQueryBuilder';
 
 const DATA_REQUIREMENTS_PATIENT = [
   {
@@ -133,5 +137,28 @@ describe('retrieveAllBulkData Tests', () => {
     });
     await retrieveAllBulkData('https://example.com/$export');
     expect(qbdSpy).toHaveBeenCalledWith('https://example.com/$export');
+  });
+});
+
+describe('retrieveBulkDataFromRequirements Tests', () => {
+  test('Should call queryBulkDataServer with existing type and type filter parameters from url', async () => {
+    const qbdSpy = jest.spyOn(exportQueries, 'queryBulkDataServer').mockImplementationOnce(async () => {
+      return { output: null };
+    });
+    await retrieveBulkDataFromRequirements(
+      DATA_REQUIREMENTS_MULTIPLE,
+      'https://example.com/$export?_type=testType&_typeFilter=testFilter'
+    );
+    expect(qbdSpy).toHaveBeenCalledWith('https://example.com/$export?_type=testType&_typeFilter=testFilter');
+  });
+
+  test('Should call queryBulkDataServer with type and type filter parameters from requirements', async () => {
+    const qbdSpy = jest.spyOn(exportQueries, 'queryBulkDataServer').mockImplementationOnce(async () => {
+      return { output: null };
+    });
+    await retrieveBulkDataFromRequirements(DATA_REQUIREMENTS_MULTIPLE, 'https://example.com/$export', true);
+    expect(qbdSpy).toHaveBeenCalledWith(
+      'https://example.com/$export?_type=Procedure,Encounter&_typeFilter=Procedure%3Ftype%3Ain=TEST_VALUE_SET,Encounter%3Fcode%3Ain=TEST_VALUE_SET'
+    );
   });
 });


### PR DESCRIPTION
# Summary
Changes `_type` and `_typeFilter` logic for bulk export so that the parameters are no longer hard-coded.

## New behavior
Now, bulk data utilities will check if the export Url already contains the `_type` and/or `_typeFilter` parameters. If so, then the existing parameter values will override the values that would have automatically been added by BDU. This allows us to now specify the `_type` and `_typeFilter` parameters in a bulk submit-data request from the test server. If the parameters are not included in the export Url, then BDU will add on the types and type filters.

## Code changes
Changes were made to `retrieveBulkDataFromeRequirements()` to check whether the parameters are already included in the export Url and to add the parameters if they are not already included. Before, if the parameters were already included, another instance of the parameters would be appended on anyway (ex. `$export?_type=Patient?_type=Patient,Condition…`).

# Testing guidance
Run the new unit tests - they check that `retrieveBulkDataFromRequirements()` adds on the type and type filters from requirements if none are already given in the export url. If they’re in the export url already, then the `queryBulkDataServer` spy should just be using the export url that was passed in to `retrieveBulkDataFromRequirements()`.

To test with deqm-test-server, npm link bulk data utilities to deqm test server. Run the test server with `npm start`, and send various bulk submit data requests, such as:
* Send a bulk submit data request using `[bulk export server url]/$export` and check that the type and type filters are tacked on from the data requirements
* Send a bulk submit data request using `[bulk export server url]/$export?_type={insert type}` and check that another type parameter is not tacked onto the end of the export url since the parameter is already present
* Send a bulk submit data request that includes both the type and type filter parameters and check nothing gets added to the url

