### PR TITLE
Added static exportType option

### DIFF
--- a/src/bulkImportWrappers.ts
+++ b/src/bulkImportWrappers.ts
@@ -1,16 +1,22 @@
 import { retrieveAllBulkData, retrieveBulkDataFromMeasureBundle } from './utils/requirementsQueryBuilder';
 import { BulkDataResponse } from './types/requirementsQueryTypes';
+import { getStaticManifest } from './utils/exportServerQueryBuilder';
 
 export async function executeBulkImport(
   exportUrl: string,
+  exportType?: string,
   mb?: fhir4.Bundle,
   useTypeFilters?: boolean
 ): Promise<BulkDataResponse[] | null> {
   let bulkDataResponses = null;
-  if (mb) {
-    ({ output: bulkDataResponses } = await retrieveBulkDataFromMeasureBundle(mb, exportUrl, useTypeFilters));
+  if (exportType === 'static') {
+    ({ output: bulkDataResponses } = await getStaticManifest(exportUrl));
   } else {
-    ({ output: bulkDataResponses } = await retrieveAllBulkData(exportUrl));
+    if (mb) {
+      ({ output: bulkDataResponses } = await retrieveBulkDataFromMeasureBundle(mb, exportUrl, useTypeFilters));
+    } else {
+      ({ output: bulkDataResponses } = await retrieveAllBulkData(exportUrl));
+    }
   }
   if (bulkDataResponses) {
     return bulkDataResponses;

--- a/src/utils/exportServerQueryBuilder.ts
+++ b/src/utils/exportServerQueryBuilder.ts
@@ -13,7 +13,6 @@ const headers = {
  */
 export async function queryBulkDataServer(url: string): Promise<{ output: BulkDataResponse[] | null }> {
   try {
-    // add if statement if exportTYpe is static then just send get request
     const resp = await axios.get(url, { headers });
     return await probeServer(resp.headers['content-location']);
   } catch (e) {
@@ -52,7 +51,7 @@ export async function probeServer(url: string): Promise<{ output: BulkDataRespon
 }
 
 /**
- * Function to handle get request when the exportType is static
+ * Handles the GET request when the exportType is static.
  */
 export async function getStaticManifest(url: string): Promise<{ output: BulkDataResponse[] | null }> {
   let results;

--- a/src/utils/exportServerQueryBuilder.ts
+++ b/src/utils/exportServerQueryBuilder.ts
@@ -13,6 +13,7 @@ const headers = {
  */
 export async function queryBulkDataServer(url: string): Promise<{ output: BulkDataResponse[] | null }> {
   try {
+    // add if statement if exportTYpe is static then just send get request
     const resp = await axios.get(url, { headers });
     return await probeServer(resp.headers['content-location']);
   } catch (e) {
@@ -46,6 +47,25 @@ export async function probeServer(url: string): Promise<{ output: BulkDataRespon
   } else if (results) {
     throw new Error(`Unexpected response from bulk export server status: ${results.status}`);
   } else {
-    throw new Error('An unknown ocurred while retrieving data from bulk export server');
+    throw new Error('An unknown occurred while retrieving data from bulk export server');
+  }
+}
+
+/**
+ * Function to handle get request when the exportType is static
+ */
+export async function getStaticManifest(url: string): Promise<{ output: BulkDataResponse[] | null }> {
+  let results;
+  try {
+    results = await axios.get(url, { headers });
+  } catch (e) {
+    throw new Error(`Failed reaching out to bulk export server with message: ${e.message}`);
+  }
+  if (results && results.status === 200) {
+    return { output: results.data.output };
+  } else if (results) {
+    throw new Error(`Unexpected response form bulk export server status: ${results.status}`);
+  } else {
+    throw new Error('An unknown error occurred while retrieving data from bulk export server');
   }
 }

--- a/src/utils/exportServerQueryBuilder.ts
+++ b/src/utils/exportServerQueryBuilder.ts
@@ -51,7 +51,8 @@ export async function probeServer(url: string): Promise<{ output: BulkDataRespon
 }
 
 /**
- * Handles the GET request when the exportType is static.
+ * When the exportType is "static", a GET request is issued to the export Url to retrieve
+ * a manifest file with the location of the bulk data files.
  */
 export async function getStaticManifest(url: string): Promise<{ output: BulkDataResponse[] | null }> {
   let results;

--- a/test/exportServerQueryBuilder.test.ts
+++ b/test/exportServerQueryBuilder.test.ts
@@ -6,7 +6,7 @@ const INVALID_URL_ERROR = 'connect ECONNREFUSED 127.0.0.1:80';
 const EXPECTED_INVALID_URL_RESPONSE = `Failed reaching out to bulk export server with message: ${INVALID_URL_ERROR}`;
 const ERROR_STATUS = { status: 500 };
 const EXPECTED_STATUS_ERROR_RESPONSE = `Unexpected response from bulk export server status: ${ERROR_STATUS.status}`;
-const EXPECTED_UNKNOWN_ERROR_RESPONSE = 'An unknown ocurred while retrieving data from bulk export server';
+const EXPECTED_UNKNOWN_ERROR_RESPONSE = 'An unknown occurred while retrieving data from bulk export server';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;


### PR DESCRIPTION
# Summary
[import-pnp.md](https://github.com/smart-on-fhir/bulk-import/blob/master/import-pnp.md#parameters) describes how a FHIR Parameteres resource MAY include a `exportType` parameter with a string of `static` or `dynamic`. This document also explains the difference is how the two types are handled. Before, we only handled if the `exportType` was `dynamic` because if `exportType` is omitted, it defaults to `dynamic`. Now, the `static` `exportType` is implemented.
 
## New behavior
The behavior now reflects the `exportType` functionality outlined in [import-pnp.md](https://github.com/smart-on-fhir/bulk-import/blob/master/import-pnp.md#parameters).

## Code changes
- `src/bulkImportWrappers.ts` - the `executeBulkImport` function now takes an additional optional parameter, `exportType`. This way if `exportType` exists and is of type `static`, then a new function will be called that handles this export type. 
- `src/utils/exportServerQueryBuilder.ts` - a new function `getStaticManifest` handles the request if the `exportType` is `static`. It issues a GET request to the export Url to retrieve a manifest file with the location of the bulk data files.
- `test/exportServerQueryBuilder.test.ts` - fixed a small typo.

# Testing guidance
- This goes hand-in-hand with the PR in the `deqm-test-server` repository, so make sure you read both of them as well as the [Jira ticket ](https://jira.mitre.org/browse/TACOSTRAT-1126). 
- You want to run `deqm-test-server` with this local copy of `bulk-data-utilities`, so within this repository, run `npm link`. 
- The rest of the testing instructions will be outlined in [https://github.com/projecttacoma/deqm-test-server/pull/123](https://github.com/projecttacoma/deqm-test-server/pull/123).
